### PR TITLE
Drop 3.8 support

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.9', '3.10', '3.11', '3.12']
 
     steps:
     - uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ Test helpers for the [requests](https://docs.python-requests.org) library
 
 ## Installation
 
-Install the package `requtests` version `1.2+` from PyPI.
-The recommended `requirements.txt` line is `requtests~=1.2`.
+Install the package `requtests` version `2.0+` from PyPI.
+The recommended `requirements.txt` line is `requtests~=2.0`.
 
 ### `FakeAdapter`
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,12 +14,11 @@ keywords = ["Requests Testing"]
 license = MIT
 long_description = file: README.md
 long_description_content_type = text/markdown
-requires_python = ~=3.8
+requires_python = ~=3.9
 classifiers =
   Development Status :: 5 - Production/Stable
   License :: OSI Approved :: MIT License
   Programming Language :: Python :: 3
-  Programming Language :: Python :: 3.8
   Programming Language :: Python :: 3.9
   Programming Language :: Python :: 3.10
   Programming Language :: Python :: 3.11

--- a/src/requtests/__init__.py
+++ b/src/requtests/__init__.py
@@ -27,6 +27,4 @@ __all__ = [
     "fake_response",
     "ParsedRequest",
 ]
-__version__ = "1.2.0"
-
-VERSION = __version__
+__version__ = "2.0.0"


### PR DESCRIPTION
Active support for Python 3.8 ended 2021-05-03. Security updates will be stopped to be issued 2024-10-14.